### PR TITLE
Document paying with Stripe and the Cider API

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -4,6 +4,7 @@ title: Ingresso API docs
 language_tabs:
   - shell: cURL
   - python: Python
+  - javascript: Javascript
 
 toc_footers:
   - <a href='#how-to-get-access-to-the-api'>Sign up for a developer key</a>


### PR DESCRIPTION
This change cleans up some of the old information that pertained to legacy Stripe only, and documents the Cider API for saving payment details directly (including a list of the most important stripe metadata we wish to collect).